### PR TITLE
Fix: HTTP module no longer converting responses to dict

### DIFF
--- a/topgg/http.py
+++ b/topgg/http.py
@@ -44,7 +44,7 @@ async def _json_or_text(
     response: ClientResponse,
 ) -> Union[dict, str]:
     text = await response.text()
-    if "application/json" in response.headers["Content-Type"]::
+    if "application/json" in response.headers["Content-Type"]:
         return json.loads(text)
     return text
 

--- a/topgg/http.py
+++ b/topgg/http.py
@@ -44,7 +44,7 @@ async def _json_or_text(
     response: ClientResponse,
 ) -> Union[dict, str]:
     text = await response.text()
-    if response.headers["Content-Type"] == "application/json; charset=utf-8":
+    if "application/json" in response.headers["Content-Type"]::
         return json.loads(text)
     return text
 


### PR DESCRIPTION
Top.GG API now returns "application/json" as the Content-Type instead of "application/json; charset=utf-8". This PR fixes the issue by making the content type check less strict.
